### PR TITLE
improvement: add materials list, use shared materials

### DIFF
--- a/clovers-back/.env.example
+++ b/clovers-back/.env.example
@@ -1,5 +1,5 @@
 POSTGRES_CONNETIONINFO=postgres://postgres:local_development_passphrase@postgres/
 REDIS_CONNETIONINFO=redis://redis:6379/
-RUST_LOG=clovers_back=trace,clovers_svc_common=trace,tower_http=trace
+RUST_LOG=clovers=trace,clovers_back=trace,clovers_svc_common=trace,tower_http=trace
 LISTEN_ADDRESS=0.0.0.0:8080
 FRONTEND_ADDRESS=http://localhost:3000

--- a/clovers-batch/.env.example
+++ b/clovers-batch/.env.example
@@ -1,5 +1,5 @@
 POSTGRES_CONNETIONINFO=postgres://postgres:local_development_passphrase@postgres/
 REDIS_CONNETIONINFO=redis://redis:6379/
-RUST_LOG=clovers_batch=trace,clovers_svc_common=trace,tower_http=trace
+RUST_LOG=clovers=trace,clovers_batch=trace,clovers_svc_common=trace,tower_http=trace
 LISTEN_ADDRESS=0.0.0.0:8080
 FRONTEND_ADDRESS=http://localhost:3000

--- a/clovers-front/src/App.tsx
+++ b/clovers-front/src/App.tsx
@@ -22,6 +22,12 @@ import useWebSocket from "react-use-websocket";
 import { collectFile, handleImport, handleExport } from "./io";
 import { RenderResults } from "./RenderResults";
 import { RenderQueue } from "./RenderQueue";
+import {
+  Materials,
+  MaterialsForm,
+  NewMaterialForm,
+  defaultMaterials,
+} from "./Materials/Material";
 
 function App() {
   const [renderOptions, setRenderOptions] =
@@ -30,6 +36,7 @@ function App() {
     useState<CameraOptions>(defaultCameraOptions);
   const [sceneObjects, setSceneObjects] =
     useState<SceneObjects>(defaultSceneObjects);
+  const [materials, setMaterials] = useState<Materials>(defaultMaterials);
   const [queue, setQueue] = useState<Array<string>>([]);
   const [renders, setRenders] = useState<Array<string>>([]);
   const [message, setMessage] = useState<string>("Ready.");
@@ -72,7 +79,12 @@ function App() {
   });
 
   const handlePreview = async () => {
-    const body = collectFile(renderOptions, cameraOptions, sceneObjects);
+    const body = collectFile({
+      renderOptions,
+      cameraOptions,
+      sceneObjects,
+      materials,
+    });
     const data = {
       kind: "preview",
       body,
@@ -94,7 +106,12 @@ function App() {
 
   const handleRender = async () => {
     setMessage("Ready.");
-    const body = collectFile(renderOptions, cameraOptions, sceneObjects);
+    const body = collectFile({
+      renderOptions,
+      cameraOptions,
+      sceneObjects,
+      materials,
+    });
 
     try {
       if (!REACT_APP_BACKEND) {
@@ -176,14 +193,20 @@ function App() {
               handlePreview={handlePreview}
               handleRender={handleRender}
               handleImport={() =>
-                handleImport({ setMessage, setCameraOptions, setSceneObjects })
+                handleImport({
+                  setMessage,
+                  setCameraOptions,
+                  setSceneObjects,
+                  setMaterials,
+                })
               }
               handleExport={() => {
-                const { scene_file } = collectFile(
+                const { scene_file } = collectFile({
                   renderOptions,
                   cameraOptions,
-                  sceneObjects
-                );
+                  sceneObjects,
+                  materials,
+                });
                 handleExport(scene_file);
               }}
             />
@@ -224,7 +247,9 @@ function App() {
           />
         </div>
         <div className="RightGroup">
-          <h2>materials tbd</h2>
+          <h2>materials</h2>
+          <NewMaterialForm setState={setMaterials} path={[]} />
+          <MaterialsForm materials={materials} setMaterials={setMaterials} />
         </div>
       </main>
       <footer>

--- a/clovers-front/src/Forms/Scene.tsx
+++ b/clovers-front/src/Forms/Scene.tsx
@@ -16,13 +16,7 @@ export const defaultSceneObjects: SceneObjects = [
     q: [555, 0, 0],
     u: [0, 0, 555],
     v: [0, 555, 0],
-    material: {
-      kind: "Lambertian",
-      albedo: {
-        kind: "SolidColor",
-        color: [0.12, 0.45, 0.15],
-      },
-    },
+    material: "green wall",
     comment: "green wall, left",
     priority: false,
   },
@@ -31,13 +25,7 @@ export const defaultSceneObjects: SceneObjects = [
     q: [0, 0, 555],
     u: [0, 0, -555],
     v: [0, 555, 0],
-    material: {
-      kind: "Lambertian",
-      albedo: {
-        kind: "SolidColor",
-        color: [0.65, 0.05, 0.05],
-      },
-    },
+    material: "red wall",
     comment: "red wall, right",
     priority: false,
   },
@@ -46,13 +34,7 @@ export const defaultSceneObjects: SceneObjects = [
     q: [0, 0, 0],
     u: [555, 0, 0],
     v: [0, 0, 555],
-    material: {
-      kind: "Lambertian",
-      albedo: {
-        kind: "SolidColor",
-        color: [0.73, 0.73, 0.73],
-      },
-    },
+    material: "grey wall",
     comment: "floor",
     priority: false,
   },
@@ -61,13 +43,7 @@ export const defaultSceneObjects: SceneObjects = [
     q: [0, 555, 0],
     u: [555, 0, 0],
     v: [0, 0, 555],
-    material: {
-      kind: "Lambertian",
-      albedo: {
-        kind: "SolidColor",
-        color: [0.73, 0.73, 0.73],
-      },
-    },
+    material: "grey wall",
     comment: "ceiling",
     priority: false,
   },
@@ -76,13 +52,7 @@ export const defaultSceneObjects: SceneObjects = [
     q: [0, 0, 555],
     u: [555, 0, 0],
     v: [0, 555, 0],
-    material: {
-      kind: "Lambertian",
-      albedo: {
-        kind: "SolidColor",
-        color: [0.73, 0.73, 0.73],
-      },
-    },
+    material: "grey wall",
     comment: "back wall",
     priority: false,
   },
@@ -91,13 +61,7 @@ export const defaultSceneObjects: SceneObjects = [
     q: [113, 554, 127],
     u: [330, 0, 0],
     v: [0, 0, 305],
-    material: {
-      kind: "DiffuseLight",
-      emit: {
-        kind: "SolidColor",
-        color: [7, 7, 7],
-      },
-    },
+    material: "lamp",
     comment: "big ceiling light",
     priority: true,
   },
@@ -115,14 +79,7 @@ export const defaultSceneObjects: SceneObjects = [
         kind: "Boxy",
         corner_0: [0, 0, 0],
         corner_1: [165, 330, 165],
-        priority: false,
-        material: {
-          kind: "Lambertian",
-          albedo: {
-            kind: "SolidColor",
-            color: [0.73, 0.73, 0.73],
-          },
-        },
+        material: "grey wall",
         comment: "tall box",
       },
     },
@@ -131,11 +88,7 @@ export const defaultSceneObjects: SceneObjects = [
     kind: "Sphere",
     center: [190, 90, 190],
     radius: 90,
-    material: {
-      kind: "Dielectric",
-      refractive_index: 1.5,
-      color: [1, 1, 1],
-    },
+    material: "glass",
     comment: "glass sphere",
     priority: true,
   },

--- a/clovers-front/src/Materials/Dielectric.tsx
+++ b/clovers-front/src/Materials/Dielectric.tsx
@@ -1,11 +1,13 @@
 import { ReactElement } from "react";
 import { DeleteButton } from "../Inputs/DeleteButton";
 import { TripleNumberInput, NumberInput } from "../Inputs/Number";
+import { TextInput } from "../Inputs/Text";
 
 export type Dielectric = {
   kind: "Dielectric";
   color: [number, number, number];
   refractive_index: number;
+  name: string;
 };
 
 export const DielectricForm = ({
@@ -17,10 +19,16 @@ export const DielectricForm = ({
   path: R.Path;
   setState: React.Dispatch<React.SetStateAction<Dielectric>>;
 }): ReactElement => {
-  const mat = "Dielectric";
+  const kind = "Dielectric";
   return (
     <div className="OptionsForm">
-      <h3>{mat}</h3>
+      <h3>{material.name || kind}</h3>
+      <TextInput
+        fieldname="name"
+        object={material}
+        path={path}
+        setState={setState}
+      />
       <DeleteButton path={path} setState={setState} />
       <NumberInput
         fieldname="refractive_index"

--- a/clovers-front/src/Materials/DiffuseLight.tsx
+++ b/clovers-front/src/Materials/DiffuseLight.tsx
@@ -1,10 +1,12 @@
 import { ReactElement } from "react";
 import { DeleteButton } from "../Inputs/DeleteButton";
 import { Texture, TextureForm } from "../Textures/Texture";
+import { TextInput } from "../Inputs/Text";
 
 export type DiffuseLight = {
   kind: "DiffuseLight";
   emit: Texture;
+  name: string;
 };
 
 export const DiffuseLightForm = ({
@@ -16,10 +18,16 @@ export const DiffuseLightForm = ({
   path: R.Path;
   setState: React.Dispatch<React.SetStateAction<DiffuseLight>>;
 }): ReactElement => {
-  const mat = "DiffuseLight";
+  const kind = "DiffuseLight";
   return (
     <div className="OptionsForm">
-      <h3>{mat}</h3>
+      <h3>{material.name || kind}</h3>
+      <TextInput
+        fieldname="name"
+        object={material}
+        path={path}
+        setState={setState}
+      />
       <DeleteButton path={path} setState={setState} />
       <TextureForm
         texture={material.emit}

--- a/clovers-front/src/Materials/Isotropic.tsx
+++ b/clovers-front/src/Materials/Isotropic.tsx
@@ -1,10 +1,12 @@
 import { ReactElement } from "react";
 import { DeleteButton } from "../Inputs/DeleteButton";
 import { Texture, TextureForm } from "../Textures/Texture";
+import { TextInput } from "../Inputs/Text";
 
 export type Isotropic = {
   kind: "Isotropic";
   albedo: Texture;
+  name: string;
 };
 
 export const IsotropicForm = ({
@@ -16,10 +18,16 @@ export const IsotropicForm = ({
   path: R.Path;
   setState: React.Dispatch<React.SetStateAction<Isotropic>>;
 }): ReactElement => {
-  const mat = "Isotropic";
+  const kind = "Isotropic";
   return (
     <div className="OptionsForm">
-      <h3>{mat}</h3>
+      <h3>{material.name || kind}</h3>
+      <TextInput
+        fieldname="name"
+        object={material}
+        path={path}
+        setState={setState}
+      />
       <DeleteButton path={path} setState={setState} />
       <TextureForm
         texture={material.albedo}

--- a/clovers-front/src/Materials/Lambertian.tsx
+++ b/clovers-front/src/Materials/Lambertian.tsx
@@ -1,10 +1,12 @@
 import { ReactElement } from "react";
 import { DeleteButton } from "../Inputs/DeleteButton";
 import { Texture, TextureForm } from "../Textures/Texture";
+import { TextInput } from "../Inputs/Text";
 
 export type Lambertian = {
   kind: "Lambertian";
   albedo: Texture;
+  name: string;
 };
 
 export const LambertianForm = ({
@@ -16,10 +18,16 @@ export const LambertianForm = ({
   path: R.Path;
   setState: React.Dispatch<React.SetStateAction<Lambertian>>;
 }): ReactElement => {
-  const mat = "Lambertian";
+  const kind = "Lambertian";
   return (
     <div className="OptionsForm">
-      <h3>{mat}</h3>
+      <h3>{material.name || kind}</h3>
+      <TextInput
+        fieldname="name"
+        object={material}
+        path={path}
+        setState={setState}
+      />
       <DeleteButton path={path} setState={setState} />
       <TextureForm
         texture={material.albedo}

--- a/clovers-front/src/Materials/Material.tsx
+++ b/clovers-front/src/Materials/Material.tsx
@@ -15,12 +15,55 @@ export type Material =
   | Metal;
 
 // TODO: can this be cleaner?
-const MaterialNames = [
+const MaterialKinds = [
   "Dielectric",
   "DiffuseLight",
   "Isotropic",
   "Lambertian",
   "Metal",
+];
+
+export type Materials = Array<Material>;
+
+export const defaultMaterials: Array<Material> = [
+  {
+    name: "lamp",
+    kind: "DiffuseLight",
+    emit: {
+      kind: "SolidColor",
+      color: [7, 7, 7],
+    },
+  },
+  {
+    name: "glass",
+    kind: "Dielectric",
+    refractive_index: 1.5,
+    color: [1, 1, 1],
+  },
+  {
+    name: "green wall",
+    kind: "Lambertian",
+    albedo: {
+      kind: "SolidColor",
+      color: [0.12, 0.45, 0.15],
+    },
+  },
+  {
+    name: "red wall",
+    kind: "Lambertian",
+    albedo: {
+      kind: "SolidColor",
+      color: [0.65, 0.05, 0.05],
+    },
+  },
+  {
+    name: "grey wall",
+    kind: "Lambertian",
+    albedo: {
+      kind: "SolidColor",
+      color: [0.73, 0.73, 0.73],
+    },
+  },
 ];
 
 const DebugForm = ({ material }: { material: Material }): ReactElement => {
@@ -76,7 +119,7 @@ export const MaterialForm = ({
   }
 };
 
-export const MaterialSelect = ({
+export const NewMaterialSelect = ({
   id,
   selected,
   setSelected,
@@ -85,7 +128,7 @@ export const MaterialSelect = ({
   selected: string;
   setSelected: React.Dispatch<React.SetStateAction<string>>;
 }): ReactElement => {
-  const options = MaterialNames.map((name, index) => (
+  const options = MaterialKinds.map((name, index) => (
     <option value={name} key={index}>
       {name}
     </option>
@@ -114,7 +157,11 @@ export const NewMaterialForm = ({
   return (
     <>
       <label htmlFor={id}>new material: </label>
-      <MaterialSelect id={id} selected={selected} setSelected={setSelected} />
+      <NewMaterialSelect
+        id={id}
+        selected={selected}
+        setSelected={setSelected}
+      />
       <Button
         handleClick={() =>
           setState((prevState: any) => {
@@ -135,5 +182,30 @@ export const NewMaterialForm = ({
         text={"add"}
       />
     </>
+  );
+};
+
+export const MaterialsForm = ({
+  materials,
+  setMaterials,
+}: {
+  materials: Materials;
+  setMaterials: any;
+}): ReactElement => {
+  return (
+    <div>
+      {materials &&
+        materials.map((mat, index) => (
+          <details>
+            <summary>{mat.name || mat.kind}</summary>
+            <MaterialForm
+              material={mat}
+              path={[index]}
+              key={index}
+              setState={setMaterials}
+            />
+          </details>
+        ))}
+    </div>
   );
 };

--- a/clovers-front/src/Materials/Material.tsx
+++ b/clovers-front/src/Materials/Material.tsx
@@ -155,8 +155,9 @@ export const NewMaterialForm = ({
   const [selected, setSelected] = useState("Lambertian");
 
   return (
-    <>
-      <label htmlFor={id}>new material: </label>
+    <div className="OptionsForm">
+      <h3>new material</h3>
+      <label htmlFor={id}>kind: </label>
       <NewMaterialSelect
         id={id}
         selected={selected}
@@ -181,7 +182,7 @@ export const NewMaterialForm = ({
         }
         text={"add"}
       />
-    </>
+    </div>
   );
 };
 

--- a/clovers-front/src/Materials/Metal.tsx
+++ b/clovers-front/src/Materials/Metal.tsx
@@ -2,11 +2,13 @@ import { ReactElement } from "react";
 import { DeleteButton } from "../Inputs/DeleteButton";
 import { NumberInput } from "../Inputs/Number";
 import { Texture, TextureForm } from "../Textures/Texture";
+import { TextInput } from "../Inputs/Text";
 
 export type Metal = {
   kind: "Metal";
   albedo: Texture;
   fuzz: number;
+  name: string;
 };
 
 export const MetalForm = ({
@@ -18,9 +20,16 @@ export const MetalForm = ({
   path: R.Path;
   setState: React.Dispatch<React.SetStateAction<Metal>>;
 }): ReactElement => {
+  const kind = "Metal";
   return (
     <div className="OptionsForm">
-      <h3>Metal</h3>
+      <h3>{material.name || kind}</h3>
+      <TextInput
+        fieldname="name"
+        object={material}
+        path={path}
+        setState={setState}
+      />
       <DeleteButton path={path} setState={setState} />
       <NumberInput
         fieldname="fuzz"

--- a/clovers-front/src/Objects/Boxy.tsx
+++ b/clovers-front/src/Objects/Boxy.tsx
@@ -3,14 +3,13 @@ import { DeleteButton } from "../Inputs/DeleteButton";
 import { TripleNumberInput } from "../Inputs/Number";
 import { TextInput } from "../Inputs/Text";
 import { CheckboxInput } from "../Inputs/Checkbox";
-import { Material, MaterialForm } from "../Materials/Material";
 
 export type Boxy = {
   kind: "Boxy";
   comment?: string;
   corner_0: [number, number, number];
   corner_1: [number, number, number];
-  material: Material;
+  material: string;
   priority: boolean;
 };
 
@@ -51,9 +50,10 @@ export const BoxyForm = ({
         path={path}
         setState={setState}
       />
-      <MaterialForm
-        material={object.material}
-        path={[...path, "material"]}
+      <TextInput
+        fieldname="material"
+        object={object}
+        path={path}
         setState={setState}
       />
     </div>

--- a/clovers-front/src/Objects/MovingSphere.tsx
+++ b/clovers-front/src/Objects/MovingSphere.tsx
@@ -3,7 +3,6 @@ import { DeleteButton } from "../Inputs/DeleteButton";
 import { NumberInput, TripleNumberInput } from "../Inputs/Number";
 import { TextInput } from "../Inputs/Text";
 import { CheckboxInput } from "../Inputs/Checkbox";
-import { Material, MaterialForm } from "../Materials/Material";
 
 export type MovingSphere = {
   kind: "MovingSphere";
@@ -13,7 +12,7 @@ export type MovingSphere = {
   time_0: number;
   time_1: number;
   radius: number;
-  material: Material;
+  material: string;
   aabb: any; // TODO: remove when fixed in upstream
   priority: boolean;
 };
@@ -73,9 +72,10 @@ export const MovingSphereForm = ({
         path={path}
         setState={setState}
       />
-      <MaterialForm
-        material={object.material}
-        path={[...path, "material"]}
+      <TextInput
+        fieldname="material"
+        object={object}
+        path={path}
         setState={setState}
       />
     </div>

--- a/clovers-front/src/Objects/Quad.tsx
+++ b/clovers-front/src/Objects/Quad.tsx
@@ -3,7 +3,6 @@ import { DeleteButton } from "../Inputs/DeleteButton";
 import { TripleNumberInput } from "../Inputs/Number";
 import { TextInput } from "../Inputs/Text";
 import { CheckboxInput } from "../Inputs/Checkbox";
-import { Material, MaterialForm } from "../Materials/Material";
 
 export type Quad = {
   kind: "Quad";
@@ -11,7 +10,7 @@ export type Quad = {
   q: [number, number, number];
   u: [number, number, number];
   v: [number, number, number];
-  material: Material;
+  material: string;
   priority: boolean;
 };
 
@@ -58,9 +57,10 @@ export const QuadForm = ({
         path={path}
         setState={setState}
       />
-      <MaterialForm
-        material={object.material}
-        path={[...path, "material"]}
+      <TextInput
+        fieldname="material"
+        object={object}
+        path={path}
         setState={setState}
       />
     </div>

--- a/clovers-front/src/Objects/STL.tsx
+++ b/clovers-front/src/Objects/STL.tsx
@@ -4,7 +4,6 @@ import { DeleteButton } from "../Inputs/DeleteButton";
 import { NumberInput, TripleNumberInput } from "../Inputs/Number";
 import { TextInput } from "../Inputs/Text";
 import { CheckboxInput } from "../Inputs/Checkbox";
-import { Material, MaterialForm } from "../Materials/Material";
 
 export type STL = {
   kind: "STL";
@@ -13,7 +12,7 @@ export type STL = {
   scale: number;
   center: [number, number, number];
   rotation: [number, number, number];
-  material: Material;
+  material: string;
   priority: boolean;
 };
 
@@ -67,9 +66,10 @@ export const STLForm = ({
         path={path}
         setState={setState}
       />
-      <MaterialForm
-        material={object.material}
-        path={[...path, "material"]}
+      <TextInput
+        fieldname="material"
+        object={object}
+        path={path}
         setState={setState}
       />
     </div>

--- a/clovers-front/src/Objects/SceneObject.tsx
+++ b/clovers-front/src/Objects/SceneObject.tsx
@@ -173,8 +173,8 @@ export const NewObjectForm = ({
 
   return (
     <div className="OptionsForm">
-      <h3>add an object</h3>
-      <label htmlFor={id}>type: </label>
+      <h3>new object</h3>
+      <label htmlFor={id}>kind: </label>
       <ObjectSelect id={id} selected={selected} setSelected={setSelected} />
       <Button
         handleClick={() =>

--- a/clovers-front/src/Objects/Sphere.tsx
+++ b/clovers-front/src/Objects/Sphere.tsx
@@ -3,14 +3,13 @@ import { DeleteButton } from "../Inputs/DeleteButton";
 import { NumberInput, TripleNumberInput } from "../Inputs/Number";
 import { TextInput } from "../Inputs/Text";
 import { CheckboxInput } from "../Inputs/Checkbox";
-import { Material, MaterialForm } from "../Materials/Material";
 
 export type Sphere = {
   kind: "Sphere";
   comment?: string;
   radius: number;
   center: [number, number, number];
-  material: Material;
+  material: string;
   priority: boolean;
 };
 
@@ -51,9 +50,10 @@ export const SphereForm = ({
         path={path}
         setState={setState}
       />
-      <MaterialForm
-        material={object.material}
-        path={[...path, "material"]}
+      <TextInput
+        fieldname="material"
+        object={object}
+        path={path}
         setState={setState}
       />
     </div>

--- a/clovers-front/src/Objects/Triangle.tsx
+++ b/clovers-front/src/Objects/Triangle.tsx
@@ -3,7 +3,6 @@ import { DeleteButton } from "../Inputs/DeleteButton";
 import { TripleNumberInput } from "../Inputs/Number";
 import { TextInput } from "../Inputs/Text";
 import { CheckboxInput } from "../Inputs/Checkbox";
-import { Material, MaterialForm } from "../Materials/Material";
 
 export type Triangle = {
   kind: "Triangle";
@@ -11,7 +10,7 @@ export type Triangle = {
   q: [number, number, number];
   u: [number, number, number];
   v: [number, number, number];
-  material: Material;
+  material: string;
   priority: boolean;
 };
 
@@ -58,9 +57,10 @@ export const TriangleForm = ({
         path={path}
         setState={setState}
       />
-      <MaterialForm
-        material={object.material}
-        path={[...path, "material"]}
+      <TextInput
+        fieldname="material"
+        object={object}
+        path={path}
         setState={setState}
       />
     </div>

--- a/clovers-front/src/io.ts
+++ b/clovers-front/src/io.ts
@@ -2,17 +2,20 @@ import { implicitSceneSettings, SceneObjects } from "./Forms/Scene";
 import { CameraOptions } from "./Forms/Camera";
 import { RenderOptions } from "./Forms/RenderOptions";
 import { SceneObject } from "./Objects/SceneObject";
+import { Materials } from "./Materials/Material";
 
 export type handleImportParams = {
   setMessage: (msg: string) => void;
   setCameraOptions: (camera: CameraOptions) => void;
   setSceneObjects: (sceneobjects: SceneObjects) => void;
+  setMaterials: (materials: Materials) => void;
 };
 
 export const handleImport = ({
   setMessage,
   setCameraOptions,
   setSceneObjects,
+  setMaterials,
 }: handleImportParams) => {
   // TODO: this is extremely hacky, fix later, possibly with https://caniuse.com/native-filesystem-api
   const reader = new FileReader();
@@ -31,10 +34,12 @@ export const handleImport = ({
           // background_color,
           camera,
           objects,
+          materials,
           // priority_objects, // TODO: handle import for priority objects
         } = json;
         setCameraOptions(camera);
         setSceneObjects(objects);
+        setMaterials(materials);
       } catch (e) {
         setMessage(`cannot import; could not parse scene file: ${e}`);
         return;
@@ -59,17 +64,24 @@ export const handleExport = (scene_file: any) => {
 };
 
 // TODO: proper return type
-export const collectFile = (
-  renderOptions: RenderOptions,
-  cameraOptions: CameraOptions,
-  sceneObjects: SceneObjects
-): any => {
+export const collectFile = ({
+  renderOptions,
+  cameraOptions,
+  sceneObjects,
+  materials,
+}: {
+  renderOptions: RenderOptions;
+  cameraOptions: CameraOptions;
+  sceneObjects: SceneObjects;
+  materials: Materials;
+}): any => {
   const opts = renderOptions;
   const scene_file = {
     ...implicitSceneSettings,
     camera: cameraOptions,
     objects: sceneObjects,
     priority_objects: sceneObjects.filter((obj: SceneObject) => obj.priority),
+    materials: materials,
   };
   return {
     opts,

--- a/clovers-preview/.env.example
+++ b/clovers-preview/.env.example
@@ -1,5 +1,5 @@
 POSTGRES_CONNETIONINFO=postgres://postgres:local_development_passphrase@postgres/
 REDIS_CONNETIONINFO=redis://redis:6379/
-RUST_LOG=clovers_preview=trace,clovers_svc_common=trace,tower_http=trace
+RUST_LOG=clovers=trace,clovers_preview=trace,clovers_svc_common=trace,tower_http=trace
 LISTEN_ADDRESS=0.0.0.0:8080
 FRONTEND_ADDRESS=http://localhost:3000

--- a/clovers-svc-common/Cargo.toml
+++ b/clovers-svc-common/Cargo.toml
@@ -7,9 +7,10 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
-clovers = { git = "https://github.com/Walther/clovers/", rev = "d69304066dd538e08439e7a9f0e27e15ba336a5a", default-features = false, features = [
+clovers = { git = "https://github.com/Walther/clovers/", rev = "c3f4db460f9d27ae0c2303ee53dfc0ce45c9e525", default-features = false, features = [
   "serde-derive",
   "stl",
+  "traces",
 ] }
 dotenv = "0.15.0"
 rand = { version = "0.8.5", features = ["small_rng"], default-features = false }

--- a/clovers-svc-common/Cargo.toml
+++ b/clovers-svc-common/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 anyhow = "1.0.75"
-clovers = { git = "https://github.com/Walther/clovers/", rev = "48ca4b0821a2e13b57f428577a4f35106be8c001", default-features = false, features = [
+clovers = { git = "https://github.com/Walther/clovers/", rev = "d69304066dd538e08439e7a9f0e27e15ba336a5a", default-features = false, features = [
   "serde-derive",
   "stl",
 ] }


### PR DESCRIPTION
Utilize the feature added in the engine at https://github.com/Walther/clovers/pull/183

Note: objects should have a dropdown select for the material, instead of the current string input (no validation!)
However, this would probably require larger changes to the state management in the frontend, so leaving as a todo for later.